### PR TITLE
release/v1

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -51,7 +51,7 @@ jobs:
           token: ${{ secrets.NUGET_TOKEN }}
           configuration: ${{ inputs.configuration }}
           level: ${{ inputs.level }}
-          downloadBuildArtifactName: ${{ inputs.configuration) }}
+          downloadBuildArtifactName: ${{ inputs.downloadBuildArtifactName }}
 
   deploy_environment:
     if: ${{ inputs.environment != '' }}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
     secrets: inherit
 ```
 
-## Contributing to Reusable Workflows for SonarQube Cloud
+## Contributing to Reusable Workflows for NuGet by Microsoft
 
 Contributions are welcome! 
 Feel free to submit issues, feature requests, or pull requests to help improve these workflows.


### PR DESCRIPTION
This pull request includes a small but important fix in the `.github/workflows/default.yml` file. The change corrects the `downloadBuildArtifactName` input to use the correct input parameter.

* [`.github/workflows/default.yml`](diffhunk://#diff-54411c2dc70cdd657fcf8a7bdebeff500fbb1245570abb83c22b3f62db03e71bL54-R54): Fixed the `downloadBuildArtifactName` input to correctly use `${{ inputs.downloadBuildArtifactName }}` instead of `${{ inputs.configuration }}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a syntax error in the deployment workflow to ensure correct artifact handling during deployment.

- **Documentation**
  - Updated the contribution section heading in the README to reflect NuGet workflows by Microsoft.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->