### PR TITLE
:pencil2: fixed typo

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -68,4 +68,4 @@ jobs:
           token: ${{ secrets.NUGET_TOKEN }}
           configuration: ${{ inputs.configuration }}
           level: ${{ inputs.level }}
-          downloadBuildArtifactName: ${{ inputs.configuration) }}
+          downloadBuildArtifactName: ${{ inputs.configuration }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/default.yml` file. The change corrects a typo in the `downloadBuildArtifactName` parameter to properly use the `inputs.configuration` value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a syntax error in the deployment workflow to ensure proper handling of configuration inputs during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->